### PR TITLE
Add file extension fallback for non-PSI languages

### DIFF
--- a/src/main/kotlin/com/github/asoee/cursorlessjetbrains/util/PsiUtil.kt
+++ b/src/main/kotlin/com/github/asoee/cursorlessjetbrains/util/PsiUtil.kt
@@ -68,5 +68,45 @@ fun editorLanguage(editor: Editor): String? {
 }
 
 fun editorLanguage(psiFile: PsiFile?): String? {
-    return psiFile?.language?.id?.lowercase()
+    val psiLanguage = psiFile?.language?.id?.lowercase()
+
+    // If PSI gives us a real language (not generic text/plaintext), use it
+    if (psiLanguage != null && psiLanguage != "text" && psiLanguage != "plaintext") {
+        return psiLanguage
+    }
+
+    // Fall back to file extension mapping for non-PSI languages
+    val fileName = psiFile?.virtualFile?.name ?: return psiLanguage
+    val extension = fileName.substringAfterLast('.', "").lowercase()
+
+    // Map file extensions to language IDs that Cursorless supports
+    // This list should match the tree-sitter WASM parsers in extraFiles/treesitter/wasm/
+    // When updating, check the upstream Cursorless project for new language support:
+    // - WASM files: packages/cursorless-engine/src/languages/TreeSitterWasmLanguages.ts
+    // - Language queries: packages/cursorless-engine/src/languages/LanguageDefinitions.ts
+    return when (extension) {
+        "talon" -> "talon"
+        "scm" -> "query"  // tree-sitter query files
+        "nix" -> "nix"
+        "gleam" -> "gleam"
+        "gdscript", "gd" -> "gdscript"
+        "hcl", "tf" -> "hcl"
+        "jl" -> "julia"
+        "tex" -> "latex"
+        "pl" -> "perl"
+        "r" -> "r"
+        "scala", "sc" -> "scala"
+        "sparql" -> "sparql"
+        "swift" -> "swift"
+        "yaml", "yml" -> "yaml"
+        "agda" -> "agda"
+        "clj", "cljs", "cljc" -> "clojure"
+        "dart" -> "dart"
+        "dtd" -> "dtd"
+        "ex", "exs" -> "elixir"
+        "elm" -> "elm"
+        "hs" -> "haskell"
+        "lua" -> "lua"
+        else -> psiLanguage ?: "plaintext"
+    }
 }


### PR DESCRIPTION
## Summary
- Added file extension-based language detection fallback for languages without PSI support
- Enables Cursorless to work with languages like Talon in JetBrains IDEs
- Preserves PSI as the primary language detection method

## Details
Languages like Talon don't have PSI (Program Structure Interface) support in JetBrains but are supported by Cursorless via tree-sitter. This change adds a fallback mechanism that detects language by file extension when PSI returns null or generic text/plaintext.

The extension mapping covers all languages that have tree-sitter WASM parsers bundled with the plugin, including:
- `.talon` → `talon`
- `.scm` → `query` (tree-sitter query files)
- `.nix` → `nix`
- And many others (see code for full list)

PSI language detection remains the primary method, with extension-based detection only used as a fallback. This ensures existing functionality is preserved while extending support to non-PSI languages.

## Test plan
- [ ] Open a `.talon` file in IntelliJ
- [ ] Verify Cursorless recognizes it as a Talon file
- [ ] Test that existing language detection for PSI-supported languages still works
- [ ] Verify other non-PSI languages from the mapping work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)