### PR TITLE
Dirty solution for getting the plugin working with 2026.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,7 @@
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.jetbrains.changelog.Changelog
 import org.jetbrains.changelog.markdownToHTML
+import org.jetbrains.intellij.platform.gradle.IntelliJPlatformType
 import org.jetbrains.intellij.platform.gradle.TestFrameworkType
 import org.jetbrains.intellij.platform.gradle.tasks.PrepareSandboxTask
 
@@ -19,7 +20,7 @@ version = providers.gradleProperty("pluginVersion").get()
 
 // Set the JVM language level used to build the project.
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 // Configure project's dependencies
@@ -78,7 +79,6 @@ dependencies {
         // Plugin Dependencies. Uses `platformPlugins` property from the gradle.properties file for plugin from JetBrains Marketplace.
         plugins(providers.gradleProperty("platformPlugins").map { it.split(',') })
 
-//        instrumentationTools()
         pluginVerifier()
         zipSigner()
         testFramework(TestFrameworkType.Platform)
@@ -146,7 +146,7 @@ intellijPlatform {
 
     pluginVerification {
         ides {
-            create("IC", "2025.1.6")
+            create(IntelliJPlatformType.IntellijIdea, "2026.2")
         }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,16 +4,15 @@ pluginGroup = com.github.asoee.cursorlessjetbrains
 pluginName = cursorless-jetbrains
 pluginRepositoryUrl = https://github.com/asoee/cursorless-jetbrains
 # SemVer format -> https://semver.org
-pluginVersion=0.0.16
+pluginVersion=0.0.16-moe
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
-pluginSinceBuild=251
+pluginSinceBuild=261
 #pluginUntilBuild=244.*
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
-platformType = IC
-platformVersion=2025.1.6
-#platformVersion=2024.3.2
+platformType = IU
+platformVersion=2026.2.0.1
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.jetbrains.php:203.4449.22, org.intellij.scala:2023.3.27@EAP

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 junit = "4.13.2"
 javet = "4.1.7"
 javenode = "0.8.0"
-kotlin = "2.2.21"
+kotlin = "2.4.10"
 kover = "0.9.3"
 qodana = "2025.1.1"
 jsvg = "2.0.0"
@@ -12,7 +12,7 @@ awaitility = "4.3.0"
 
 # plugins
 changelog = "2.4.0"
-intelliJPlatform = "2.8.0"
+intelliJPlatform = "2.18.1"
 
 [libraries]
 junit = { group = "junit", name = "junit", version.ref = "junit" }

--- a/src/main/kotlin/com/github/asoee/cursorlessjetbrains/ui/CursorlessContainer.kt
+++ b/src/main/kotlin/com/github/asoee/cursorlessjetbrains/ui/CursorlessContainer.kt
@@ -9,7 +9,6 @@ import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.colors.EditorFontType
 import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.ui.JBColor
-import groovy.json.JsonException
 import java.awt.Color
 import java.awt.Graphics
 import java.awt.Graphics2D
@@ -210,9 +209,9 @@ class CursorlessContainer(val editor: Editor) : JComponent() {
         } catch (e: IndexOutOfBoundsException) {
             // This might happen in some cases, if the document has been updated, and is shorter than the hat range
             thisLogger().warn("Index out of bounds exception in CursorlessContainer.paintComponent: " + e.message)
-        } catch (e: JsonException) {
-            e.printStackTrace()
-        }
+        } catch (e: RuntimeException) {
+            thisLogger().warn("Runtime exception in CursorlessContainer.paintComponent", e)
+     }
     }
 
     fun updateHats(format: HatsFormat) {


### PR DESCRIPTION
Hi @asoee !

Today, I updated to the most recent Idea Ultimate (2026.2.0.1), and found my beloved little hats had disappeared :')

The idea.log contained a ClassNotFound for groovy.json.JsonException in the plugin.

I made some local changes to the plugin to get a working state. I'm aware that this is not a good solution for several reasons (generic RuntimeException catch, because groovy.json.JsonException isn't available anymore; I also didn't update linting etc., I didn't care about compatibility with older releases).

One of the reason for my changes was that the distribution model has now changed (https://platform.jetbrains.com/t/intellij-platform-gradle-plugins-intellijideacommunity-deprecation/2709).

Feel free to reject this PR, of course :)